### PR TITLE
Fix malformed list in "Using Method Parameters" documentation

### DIFF
--- a/docs/modules/ROOT/pages/servlet/authorization/method-security.adoc
+++ b/docs/modules/ROOT/pages/servlet/authorization/method-security.adoc
@@ -1804,7 +1804,7 @@ The intention of this expression is to require that the current `Authentication`
 +
 Behind the scenes, this is implemented by using `AnnotationParameterNameDiscoverer`, which you can customize to support the value attribute of any specified annotation.
 
-* If xref:servlet/integrations/data.adoc[Spring Data's] `@Param` annotation is present on at least one parameter for the method, the value is used.
+2. If xref:servlet/integrations/data.adoc[Spring Data's] `@Param` annotation is present on at least one parameter for the method, the value is used.
 The following example uses the `@Param` annotation:
 +
 [tabs]
@@ -1838,10 +1838,10 @@ The intention of this expression is to require that `name` be equal to `Authenti
 +
 Behind the scenes, this is implemented by using `AnnotationParameterNameDiscoverer`, which you can customize to support the value attribute of any specified annotation.
 
-* If you compile your code with the `-parameters` argument, the standard JDK reflection API is used to discover the parameter names.
+3. If you compile your code with the `-parameters` argument, the standard JDK reflection API is used to discover the parameter names.
 This works on both classes and interfaces.
 
-* Finally, if you compile your code with debug symbols, the parameter names are discovered by using the debug symbols.
+4. Finally, if you compile your code with debug symbols, the parameter names are discovered by using the debug symbols.
 This does not work for interfaces, since they do not have debug information about the parameter names.
 For interfaces, either annotations or the `-parameters` approach must be used.
 


### PR DESCRIPTION
See [section "Using Method Parameters" in the current documentation](https://docs.spring.io/spring-security/reference/servlet/authorization/method-security.html#using_method_parameters). It looks like it is supposed to list the order in which Spring tries to discover parameter names:
1. `@P`
2. `@Param`
3. `javac` `-parameters`
4. `javac` with debug symbols

However, currently it is erroneously displayed as:
1. `@P`
   - `@Param`
   - `javac` `-parameters`
   - `javac` with debug symbols

This pull request tries to fix this.

Though please let me know if I misunderstood this, or if there is a better way to solve this.